### PR TITLE
Issues with unit tests

### DIFF
--- a/Pose.sln
+++ b/Pose.sln
@@ -1,15 +1,14 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{3D859125-47BB-49F0-ACB4-42CEE47FB562}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pose", "src\Pose\Pose.csproj", "{BBC1C0DC-ECA2-48C3-A233-0873428203AF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pose", "src\Pose\Pose.csproj", "{BBC1C0DC-ECA2-48C3-A233-0873428203AF}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{C2484D4C-4BED-46C2-BD61-2508BD8BD3C5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pose.Tests", "test\Pose.Tests\Pose.Tests.csproj", "{AE06C68C-032F-45CC-888C-54B0B98F860C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pose.Tests", "test\Pose.Tests\Pose.Tests.csproj", "{AE06C68C-032F-45CC-888C-54B0B98F860C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,37 +19,40 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Debug|x64.ActiveCfg = Debug|x64
-		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Debug|x64.Build.0 = Debug|x64
-		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Debug|x86.ActiveCfg = Debug|x86
-		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Debug|x86.Build.0 = Debug|x86
+		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Debug|x64.Build.0 = Debug|Any CPU
+		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Debug|x86.Build.0 = Debug|Any CPU
 		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Release|x64.ActiveCfg = Release|x64
-		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Release|x64.Build.0 = Release|x64
-		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Release|x86.ActiveCfg = Release|x86
-		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Release|x86.Build.0 = Release|x86
+		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Release|x64.ActiveCfg = Release|Any CPU
+		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Release|x64.Build.0 = Release|Any CPU
+		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Release|x86.ActiveCfg = Release|Any CPU
+		{BBC1C0DC-ECA2-48C3-A233-0873428203AF}.Release|x86.Build.0 = Release|Any CPU
 		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Debug|x64.ActiveCfg = Debug|x64
-		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Debug|x64.Build.0 = Debug|x64
-		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Debug|x86.ActiveCfg = Debug|x86
-		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Debug|x86.Build.0 = Debug|x86
+		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Debug|x64.Build.0 = Debug|Any CPU
+		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Debug|x86.Build.0 = Debug|Any CPU
 		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Release|x64.ActiveCfg = Release|x64
-		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Release|x64.Build.0 = Release|x64
-		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Release|x86.ActiveCfg = Release|x86
-		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Release|x86.Build.0 = Release|x86
+		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Release|x64.ActiveCfg = Release|Any CPU
+		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Release|x64.Build.0 = Release|Any CPU
+		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Release|x86.ActiveCfg = Release|Any CPU
+		{AE06C68C-032F-45CC-888C-54B0B98F860C}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{BBC1C0DC-ECA2-48C3-A233-0873428203AF} = {3D859125-47BB-49F0-ACB4-42CEE47FB562}
 		{AE06C68C-032F-45CC-888C-54B0B98F860C} = {C2484D4C-4BED-46C2-BD61-2508BD8BD3C5}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8AD5128B-533F-4FDF-9650-CE408930F7C2}
 	EndGlobalSection
 EndGlobal

--- a/src/Pose/PoseContext.cs
+++ b/src/Pose/PoseContext.cs
@@ -21,7 +21,14 @@ namespace Pose
             Shims = shims;
             Type delegateType = typeof(Action<>).MakeGenericType(entryPoint.Target.GetType());
             MethodRewriter rewriter = MethodRewriter.CreateRewriter(entryPoint.Method);
-            ((MethodInfo)(rewriter.Rewrite())).CreateDelegate(delegateType).DynamicInvoke(entryPoint.Target);
+            try
+            {
+                ((MethodInfo)(rewriter.Rewrite())).CreateDelegate(delegateType).DynamicInvoke(entryPoint.Target);
+            }
+            catch (TargetInvocationException e) when (e.InnerException != null)
+            {
+                throw e.InnerException;
+            }
         }
     }
 }

--- a/test/Pose.Tests/Pose.Tests.csproj
+++ b/test/Pose.Tests/Pose.Tests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170427-09" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.17" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.17" />
+    <PackageReference Include="Shouldly" Version="2.8.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Pose.Tests/TestingTests.cs
+++ b/test/Pose.Tests/TestingTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using static Pose.PoseContext;
+
+namespace Pose.Tests
+{
+	[TestClass]
+	public class TestingTests
+	{
+		[TestMethod]
+		public void IsolateWithoutShimShouldAllowUnitTestAssertions()
+		{
+			Isolate(() => { Assert.AreEqual(1, 1); });
+		}
+
+		[TestMethod]
+		public void IsolateWithShimShouldAllowUnitTestAssertions()
+		{
+			Isolate(() => { Assert.AreEqual(1, 1); }, SimpleShim);
+		}
+
+		[TestMethod]
+		public void IsolateWithoutShimShouldAllowShouldlyAssertions()
+		{
+			Isolate(() => { 1.ShouldBe(1); });
+		}
+
+		[TestMethod]
+		public void IsolateWithShimShouldAllowShouldlyAssertions()
+		{
+			Isolate(() => { 1.ShouldBe(1); }, SimpleShim);
+		}
+
+		[TestMethod]
+		public void IsolateWithoutShimShouldNotAffectFailedUnitTestMessages()
+		{
+			Should.NotThrow(() =>
+			{
+				try
+				{
+					Isolate(() => { 1.ShouldBe(2); });
+				}
+				catch (ShouldAssertException)
+				{
+					//This one is expected
+				}
+			});
+		}
+
+		[TestMethod]
+		public void IsolateWithShimShouldNotAffectFailedUnitTestMessages()
+		{
+			Should.NotThrow(() =>
+			{
+				try
+				{
+					Isolate(() => { 1.ShouldBe(2); }, SimpleShim);
+				}
+				catch (ShouldAssertException)
+				{
+					//This one is expected
+				}
+			});
+		}
+
+		private static Shim SimpleShim => Shim.Replace(() => Console.Clear()).With(Console.Clear);
+	}
+}


### PR DESCRIPTION
I saw this library the other day, and thought it would be useful for unit testing, but ran into some issues.  
I've added a commit with some new tests that should demonstrate the issues.

It seems that whenever the `Assert` class (from `Microsoft.VisualStudio.TestTools.UnitTesting`) is used within a PoseContext.Isolate entry point, a `InvalidProgramException` is thrown with the message `Common Language Runtime detected an invalid program.`

I'm not sure why that is, but I tried with another assertion library, [Shouldly](https://github.com/shouldly/shouldly), and this time the assertions work, but the problem is that any exceptions from failed assertions (any exceptions actually), are wrapped in a `TargetInvocationException`. This means that the failed unit tests have error messages that are not as useful as they could be. 

I've added another commit that simply catches that exception and rethrows the inner exception, which solves that particular issue, but I don't know if that is ideal. I'm not very familiar with the project and don't know if the original exception is needed or useful.

Perhaps the best way to deal with this would be to do all asserting outside of the Isolate method.