### PR TITLE
Added support for property setter shimming

### DIFF
--- a/src/Pose/Helpers/ShimHelper.cs
+++ b/src/Pose/Helpers/ShimHelper.cs
@@ -15,6 +15,7 @@ namespace Pose.Helpers
             switch (expression.NodeType)
             {
                 case ExpressionType.MemberAccess:
+                {
                     MemberExpression memberExpression = expression as MemberExpression;
                     MemberInfo memberInfo = memberExpression.Member;
                     if (memberInfo.MemberType == MemberTypes.Property)
@@ -25,6 +26,7 @@ namespace Pose.Helpers
                     }
                     else
                         throw new NotImplementedException("Unsupported expression");
+                }
                 case ExpressionType.Call:
                     MethodCallExpression methodCallExpression = expression as MethodCallExpression;
                     instance = GetObjectInstanceFromExpression(methodCallExpression.Object);
@@ -33,6 +35,18 @@ namespace Pose.Helpers
                     NewExpression newExpression = expression as NewExpression;
                     instance = null;
                     return newExpression.Constructor;
+                case ExpressionType.Assign:
+                {
+                    BinaryExpression assignExpression = (BinaryExpression)expression;
+                    MemberExpression memberExpression = (MemberExpression)assignExpression.Left;
+                    MemberInfo memberInfo = memberExpression.Member;
+                    if (memberInfo.MemberType != MemberTypes.Property)
+                        throw new NotSupportedException("Unsupported expression");
+
+                    PropertyInfo propertyInfo = (PropertyInfo)memberInfo;
+                    instance = GetObjectInstanceFromExpression(memberExpression.Expression);
+                    return propertyInfo.GetSetMethod();
+                }
                 default:
                     throw new NotImplementedException("Unsupported expression");
             }

--- a/src/Pose/Shim.cs
+++ b/src/Pose/Shim.cs
@@ -45,10 +45,9 @@ namespace Pose
 
         public static Shim Replace(Expression<Action> expression)
         {
-            MethodCallExpression methodCall = expression.Body as MethodCallExpression;
-            return new Shim(methodCall.Method, null)
+            return new Shim(ShimHelper.GetMethodFromExpression(expression.Body, out object instance), null)
             {
-                _instance = ShimHelper.GetObjectInstanceFromExpression(methodCall.Object)
+                _instance = instance
             };
         }
 

--- a/test/Pose.Tests/ShimTests.cs
+++ b/test/Pose.Tests/ShimTests.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Globalization;
+using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading;
 
 using Pose.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -58,6 +61,40 @@ namespace Pose.Tests
             Assert.AreEqual(typeof(ShimTests).GetMethod("TestReplace"), shim1.Original);
             Assert.AreSame(shimTests, shim1.Instance);
             Assert.AreEqual(actionInstance, shim1.Replacement);
+        }
+
+        [TestMethod]
+        public void TestReplacePropertyGetter()
+        {
+            Shim shim = Shim.Replace(() => Thread.CurrentThread.CurrentCulture);
+
+            Assert.AreEqual(typeof(Thread).GetProperty(nameof(Thread.CurrentCulture), typeof(CultureInfo)).GetMethod, shim.Original);
+            Assert.IsNull(shim.Replacement);
+        }
+
+        /// <summary>
+        /// The C# compiler currently does not allow poperty setters in lambda expressions.
+        /// This helper method works around that by combining a property getter expression
+        /// and a value into a setter expression.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="lvalue"></param>
+        /// <param name="rvalue"></param>
+        /// <returns></returns>
+        private static Expression<Action> Assignment<T>(Expression<Func<T>> lvalue, T rvalue)
+        {
+            var value = Expression.Constant(rvalue, typeof(T));
+            var assign = Expression.Assign(lvalue.Body, value);
+            return Expression.Lambda<Action>(assign);
+        }
+
+        [TestMethod]
+        public void TestReplacePropertySetter()
+        {
+            Shim shim = Shim.Replace(Assignment(() => Is.A<Thread>().CurrentCulture, Is.A<CultureInfo>()));
+
+            Assert.AreEqual(typeof(Thread).GetProperty(nameof(Thread.CurrentCulture), typeof(CultureInfo)).SetMethod, shim.Original);
+            Assert.IsNull(shim.Replacement);
         }
     }
 }


### PR DESCRIPTION
Hi! I played with Pose for a bit and noticed the missing support for shimming property setters.
I was able to enable support for setters with a couple of small changes.
In ShimHelpers I added handling for the Assign to property expression.

To work around the C# compiler limitation off not allowing setters in lambda expressions I used the Assigment helper method in ShimTests.
This works already but it could be better integrated, maybe a Shim.ReplaceSetter method?

I would love to hear your opinion on this change and maybe get setter support for Pose working! 